### PR TITLE
Merge latest from vscode-standard-format to fix code formatting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,16 +1,17 @@
-// A launch configuration that compiles the extension and then opens it inside a new window
 {
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"configurations": [
 		{
 			"name": "Launch Extension",
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}"
+			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out",
+			"outDir": "${workspaceRoot}/out",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +22,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out",
+			"outDir": "${workspaceRoot}/out",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Please only use it when you are ok with [JavaScript Standard Style](http://stand
 
 ## Changes
 
+### 0.0.7 (2016-02-12)
+
+1. Added keybindings notes.
+
 ### 0.0.6 (2016-02-12)
 
 1. Added a new command to workaround the [problem](https://github.com/chenxsan/vscode-standard-format/issues/1) with the latest Visual Studio Code 0.10.10
@@ -24,6 +28,17 @@ Please only use it when you are ok with [JavaScript Standard Style](http://stand
 1. Press `F1` to bring up Command Palette
 2. Search for `Format code with standard-format` and click it
 3. Done
+
+## Keybinding
+
+You can also configurate keybinding in `keybindings.json`, for example:
+
+```
+[
+  {"key": "shift+cmd+f", "command": "format.standard",
+  "when": "editorTextFocus"}
+]
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This extension adds [Standard format](https://github.com/maxogden/standard-forma
 
 Please only use it when you are ok with [JavaScript Standard Style](http://standardjs.com/).
 
+## Changes
+
+### 0.0.6 (2016-02-12)
+
+1. Added a new command to workaround the [problem](https://github.com/chenxsan/vscode-standard-format/issues/1) with the latest Visual Studio Code 0.10.10
+
+
 ## Installation
 
 1. Press `F1` to bring up Command Palette
@@ -15,7 +22,7 @@ Please only use it when you are ok with [JavaScript Standard Style](http://stand
 ## Usage
 
 1. Press `F1` to bring up Command Palette
-2. Search for `Format Code` and click it
+2. Search for `Format code with standard-format` and click it
 3. Done
 
 ## License

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ Please only use it when you are ok with [JavaScript Standard Style](http://stand
 
 ## Changes
 
-### 0.0.7 (2016-02-12)
+### 0.0.8 (2016-03-13)
+
+1. Optimized code
+2. Fixed readme
+
+### 0.0.7 (2016-03-12)
 
 1. Added keybindings notes.
 
-### 0.0.6 (2016-02-12)
+### 0.0.6 (2016-03-12)
 
 1. Added a new command to workaround the [problem](https://github.com/chenxsan/vscode-standard-format/issues/1) with the latest Visual Studio Code 0.10.10
 
@@ -27,7 +32,9 @@ Please only use it when you are ok with [JavaScript Standard Style](http://stand
 
 1. Press `F1` to bring up Command Palette
 2. Search for `Format code with standard-format` and click it
-3. Done
+3. It will format the whole document
+
+You can also format only those you selects.
 
 ## Keybinding
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-standard-format",
   "displayName": "JavaScript Standard Format",
   "description": "Converts your code into Standard JavaScript Format",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "chenxsan",
   "license": "MIT",
   "bugs": {
@@ -22,8 +22,19 @@
     "vscode": "^0.10.1"
   },
   "activationEvents": [
-    "onLanguage:javascript", "onLanguage:javascriptreact"
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "onCommand:format.standard"    
   ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "format.standard",
+        "title": "Format code with standard-format"
+      }
+    ]
+  },
   "main": "./out/src/extension",
   "scripts": {
     "vscode:prepublish": "node ./node_modules/vscode/bin/compile",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
   "main": "./out/src/extension",
   "scripts": {
     "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
     "standard-format": "^2.1.0"
   },
   "devDependencies": {
-    "typescript": "^1.6.2",
-    "vscode": "0.10.x"
+    "typescript": "^1.7.5",
+    "vscode": "0.11.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-standard-format",
   "displayName": "JavaScript Standard Format",
   "description": "Converts your code into Standard JavaScript Format",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "chenxsan",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-standard-format",
   "displayName": "JavaScript Standard Format",
   "description": "Converts your code into Standard JavaScript Format",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publisher": "chenxsan",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-standard-format",
   "displayName": "JavaScript Standard Format",
   "description": "Converts your code into Standard JavaScript Format",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "publisher": "chenxsan",
   "license": "MIT",
   "bugs": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,32 +1,32 @@
 
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode'; 
+import * as vscode from 'vscode';
 
 import standardFormat = require('standard-format');
 
-export function format(document: vscode.TextDocument, range: vscode.Range, options:vscode.FormattingOptions) {
-	
-	if (range === null) {
-		var start = new vscode.Position(0, 0);
-		var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
-		range = new vscode.Range(start, end);
-	}
+export function format(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions) {
 
-	var result: vscode.TextEdit[] = [];
-	
-	var content = document.getText(range);
-	
-	if (!options) {
-		options = { insertSpaces: true, tabSize: 4 };
-	}
-	
-	var formatted = standardFormat.transform(content);
-	if (formatted) {
-		result.push(new vscode.TextEdit(range, formatted));
-	}
-	
-	return result;
+  if (range === null) {
+    var start = new vscode.Position(0, 0);
+    var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
+    range = new vscode.Range(start, end);
+  }
+
+  var result: vscode.TextEdit[] = [];
+
+  var content = document.getText(range);
+
+  if (!options) {
+    options = { insertSpaces: true, tabSize: 4 };
+  }
+
+  var formatted = standardFormat.transform(content);
+  if (formatted) {
+    result.push(new vscode.TextEdit(range, formatted));
+  }
+
+  return result;
 };
 
 
@@ -34,16 +34,42 @@ export function format(document: vscode.TextDocument, range: vscode.Range, optio
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-	context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('javascript', {
-		provideDocumentFormattingEdits: (document, options, token) => {
-			return format(document, null, options)
-		}
-	}));
-	context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider('javascript', {
-		provideDocumentRangeFormattingEdits: (document, range, options, token) => {
-			var start = new vscode.Position(0, 0);
-			var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
-			return format(document, new vscode.Range(start, end), options)
-		}
-	}));	
+  context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('javascript', {
+    provideDocumentFormattingEdits: (document, options, token) => {
+      return format(document, null, options)
+    }
+  }));
+  context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider('javascript', {
+    provideDocumentRangeFormattingEdits: (document, range, options, token) => {
+      var start = new vscode.Position(0, 0);
+      var end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
+      return format(document, new vscode.Range(start, end), options)
+    }
+  }));
+  context.subscriptions.push(vscode.commands.registerCommand('format.standard', () => {
+    var editor = vscode.window.activeTextEditor;
+    var document = editor.document;
+    if (!editor) {
+      return; // No open text editor
+    }
+    var selection = editor.selection;
+    var start;
+    var end;
+    if (selection.start.line === selection.end.line && selection.start.character === selection.end.character) {
+      // whole document
+       start = new vscode.Position(0, 0);
+       end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
+    } else {
+      // with selection
+      start = new vscode.Position(selection.start.line, 0)
+      end = new vscode.Position(selection.end.line, document.lineAt(selection.end.line).text.length)
+    }
+    var range = new vscode.Range(start, end);
+    var content = document.getText(range);
+    var formatted = standardFormat.transform(content);
+    var result: vscode.TextEdit[] = [];
+    editor.edit((editor) => {
+      editor.replace(range, formatted)
+    })
+  }))
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,17 +46,12 @@ export function activate(context: vscode.ExtensionContext) {
       return format(document, new vscode.Range(start, end), options)
     }
   }));
-  context.subscriptions.push(vscode.commands.registerCommand('format.standard', () => {
-    var editor = vscode.window.activeTextEditor;
-    var document = editor.document;
-    if (!editor) {
-      return; // No open text editor
-    }
-    var selection = editor.selection;
+  context.subscriptions.push(vscode.commands.registerTextEditorCommand('format.standard', (textEditor, edit) => {
+    var { document, selection } = textEditor
     var start;
     var end;
     if (selection.start.line === selection.end.line && selection.start.character === selection.end.character) {
-      // whole document
+      // no selections, then whole document
        start = new vscode.Position(0, 0);
        end = new vscode.Position(document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
     } else {
@@ -68,8 +63,6 @@ export function activate(context: vscode.ExtensionContext) {
     var content = document.getText(range);
     var formatted = standardFormat.transform(content);
     var result: vscode.TextEdit[] = [];
-    editor.edit((editor) => {
-      editor.replace(range, formatted)
-    })
+    edit.replace(range, formatted);
   }))
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -40,4 +40,9 @@ suite("Extension Tests", () => {
 		var expected = "var a = 5\n";
 		assertFormatter(content, expected, done);
 	});
+    test('Function declaration', (done) => {
+        var content = 'function name() {}';
+        var expected = 'function name () {}\n';
+		assertFormatter(content, expected, done);        
+    })
 });


### PR DESCRIPTION
Currently there is a bug where "Format Code" does not actually call semistandard-format anymore.

The workaround in vscode-standard-format was to create a separate command. I've merged the code and updated it to "semistandard" wording in order to make this work again.
